### PR TITLE
Option to run pm2 startOrReload

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A set of tasks for [Shipit](https://github.com/shipitjs/shipit) used for [pm2](h
 
 **Features:**
 
-- Automatically starts or restarts your [processes.json](https://github.com/Unitech/PM2/blob/master/ADVANCED_README.md#json-app-declaration). Triggered on `published`.
+- Automatically starts or restarts (or reloads) your [processes.json](https://github.com/Unitech/PM2/blob/master/ADVANCED_README.md#json-app-declaration). Triggered on `published`.
 - Automatically updates the process `execute_interpreter` to a specific node version before start or restart. Triggered on `updated`. (Note: this currently only works with a single app process and requires [shipit-nvm](https://github.com/callerc1/shipit-nvm)).
 - Works with [shipit-deploy](https://github.com/shipitjs/shipit-deploy)
 - Has a direct pass though task to [pm2](https://github.com/Unitech/pm2) commands.
@@ -41,6 +41,13 @@ Type: `String`
 Default: *`'app.json'`*
 
 An string specifying the path to the pm2 json app declaration file (see [pm2 readme](https://github.com/Unitech/PM2/blob/master/ADVANCED_README.md#json-app-declaration) for more info).
+
+### `pm2.reload`
+
+Type: `Boolean`
+Default: *`false`
+
+If true, the app reloads gracefully with `pm2 startOrReload`.  If false, the app is restarted with `pm2 startOrRestart`.
 
 
 ### Example `shipitfile.js` options usage

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ An string specifying the path to the pm2 json app declaration file (see [pm2 rea
 ### `pm2.reload`
 
 Type: `Boolean`
-Default: *`false`
+Default: `false`
 
 If true, the app reloads gracefully with `pm2 startOrReload`.  If false, the app is restarted with `pm2 startOrRestart`.
 

--- a/tasks/pm2/init.js
+++ b/tasks/pm2/init.js
@@ -20,6 +20,7 @@ module.exports = function (gruntOrShipit) {
     shipit.currentPath = shipit.config.deployTo ? path.join(shipit.config.deployTo, 'current') : undefined;
     shipit.config.pm2 = shipit.config.pm2 || {};
     shipit.config.pm2.json = shipit.config.pm2.json || 'app.json'; //app.json could be included in your apps repo or shared
+    shipit.config.pm2.reload = shipit.config.pm2.reload || false;
     shipit.sharedPath = shipit.sharedPath || 'shared';
 
     // Allow for an absolute path

--- a/tasks/pm2/start-or-restart.js
+++ b/tasks/pm2/start-or-restart.js
@@ -5,7 +5,7 @@ var Bluebird = require('bluebird');
 var pathIsAbsolute = require('path-is-absolute');
 var path = require('path');
 /**
- * Runs pm2 start or restart
+ * Runs pm2 start or restart (reload if shipit.config.pm2.reload is set)
  */
 
 module.exports = function (gruntOrShipit) {
@@ -32,7 +32,7 @@ module.exports = function (gruntOrShipit) {
       }
 
       return shipit[method](
-        sprintf('pm2 startOrRestart %s', shipit.config.pm2.json)
+        sprintf('pm2 %s %s', shipit.config.pm2.reload ? 'startOrReload': 'startOrRestart', shipit.config.pm2.json)
       );
 
     }


### PR DESCRIPTION
This creates the option pm2.reload (default false).  When true, the restart command becomes "pm2 startOrReload" rather than the current "pm2 startOrRestart".
