### PR TITLE
Support pm2 environment-specific variables

### DIFF
--- a/tasks/pm2/start-or-restart.js
+++ b/tasks/pm2/start-or-restart.js
@@ -31,8 +31,14 @@ module.exports = function (gruntOrShipit) {
         shipit.config.pm2.json = path.join(jsonAbsPath, shipit.config.pm2.json);
       }
 
+      var envswitch = '';
+
+      if (shipit.config.pm2.env) {
+        envswitch = '--env ' + shipit.config.pm2.env;
+      }
+
       return shipit[method](
-        sprintf('pm2 startOrRestart %s', shipit.config.pm2.json)
+        sprintf('pm2 startOrRestart %s %s', shipit.config.pm2.json, envswitch)
       );
 
     }


### PR DESCRIPTION
I needed to pass the --env switch to pm2.  This patch supports the 'env' property in the pm2 config object.